### PR TITLE
Add WHV tax refund estimator prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Estimatrice de remboursement WHV</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Estimer ton remboursement d'impôts WHV</h1>
+    <form id="taxForm">
+        <label for="income_tfn">Revenu TFN (AUD):</label>
+        <input type="number" id="income_tfn" name="income_tfn" required>
+        <br>
+        <span>As-tu aussi travaillé en ABN ?</span>
+        <label><input type="radio" name="has_abn" value="Oui" checked> Oui</label>
+        <label><input type="radio" name="has_abn" value="Non"> Non</label>
+        <div id="abnSection">
+            <label for="income_abn">Revenu ABN (AUD):</label>
+            <input type="number" id="income_abn" name="income_abn" value="0">
+        </div>
+        <br>
+        <span>As-tu un TFN ?</span>
+        <label><input type="radio" name="has_tfn" value="Oui" checked> Oui</label>
+        <label><input type="radio" name="has_tfn" value="Non"> Non</label>
+        <br>
+        <label for="months">Combien de mois as-tu travaillé ?</label>
+        <input type="number" id="months" name="months" min="1" max="12" value="12">
+        <br>
+        <label for="residency_status">Ton statut fiscal :</label>
+        <select id="residency_status" name="residency_status">
+            <option value="resident">Résident</option>
+            <option value="nonresident">Non-résident</option>
+            <option value="unknown">Je sais pas</option>
+        </select>
+        <br>
+        <button type="submit">Estimer mon remboursement</button>
+    </form>
+    <div id="result" style="display:none; margin-top:20px;"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,57 @@
+(function(){
+    const form = document.getElementById('taxForm');
+    const resultDiv = document.getElementById('result');
+    const abnSection = document.getElementById('abnSection');
+    const hasAbnRadios = document.querySelectorAll('input[name="has_abn"]');
+
+    function toggleAbnSection() {
+        const hasAbn = document.querySelector('input[name="has_abn"]:checked').value === 'Oui';
+        abnSection.style.display = hasAbn ? 'block' : 'none';
+    }
+
+    hasAbnRadios.forEach(r => r.addEventListener('change', toggleAbnSection));
+    toggleAbnSection();
+
+    function formatMoney(value) {
+        return value.toLocaleString('fr-FR', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + ' $AUD';
+    }
+
+    form.addEventListener('submit', function(event){
+        event.preventDefault();
+
+        const incomeTFN = parseFloat(document.getElementById('income_tfn').value) || 0;
+        const hasABN = document.querySelector('input[name="has_abn"]:checked').value === 'Oui';
+        const incomeABN = hasABN ? (parseFloat(document.getElementById('income_abn').value) || 0) : 0;
+        const hasTFN = document.querySelector('input[name="has_tfn"]:checked').value === 'Oui';
+        const months = parseInt(document.getElementById('months').value, 10) || 0;
+        const residency = document.getElementById('residency_status').value;
+
+        // Withheld tax
+        const withheldTFN = hasTFN ? incomeTFN * 0.15 : incomeTFN * 0.45;
+
+        // Expected tax
+        let expectedTax = 0;
+        const resident = residency === 'resident';
+        if(resident){
+            const threshold = 18200;
+            const taxable = Math.max(0, incomeTFN - threshold);
+            expectedTax = taxable * 0.19;
+        } else {
+            expectedTax = incomeTFN * 0.325;
+        }
+
+        const refund = withheldTFN - expectedTax;
+
+        let output = `<p>Impôts prélevés via TFN: <strong>${formatMoney(withheldTFN)}</strong></p>`;
+        output += `<p>Impôts attendus selon ton statut: <strong>${formatMoney(expectedTax)}</strong></p>`;
+        output += `<p><strong>${refund >= 0 ? 'Remboursement estimé' : 'Montant dû' } : ${formatMoney(Math.abs(refund))}</strong></p>`;
+
+        if(hasABN && incomeABN > 0){
+            output += `<p class="warning">Attention: tu pourrais devoir environ 19–32% d'impôts sur ton revenu ABN de ${formatMoney(incomeABN)}.</p>`;
+        }
+
+        resultDiv.innerHTML = output;
+        resultDiv.className = refund >= 0 ? 'positive' : 'negative';
+        resultDiv.style.display = 'block';
+    });
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+#result.positive { color: green; }
+#result.negative { color: red; }
+#result.warning { color: orange; }
+#abnSection { margin-top: 10px; }


### PR DESCRIPTION
## Summary
- create a simple French-language WHV tax refund estimator form
- style the page and results
- implement refund logic in JS with ABN warning

## Testing
- `npm test` *(fails: could not find package.json)*